### PR TITLE
Fix names

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -31,7 +31,7 @@ jobs:
           username: ${{secrets.DOCKERHUB_USERNAME}}
           password: ${{secrets.DOCKERHUB_PASSWORD}}
 
-      - name: get lastest 1.x version
+      - name: get lastest version
         id: remote_version
         run: echo "::set-output name=version::$(lastversion https://github.com/kevinpapst/kimai2)"
 


### PR DESCRIPTION
We're not on v 1.x any more.
Alternatively, could've needed  --only '~^1\.' at the end. But I think it's more desired to build and push 2.x verions.